### PR TITLE
Validate DIA in parse_pairs

### DIFF
--- a/tests/test_dia_validation.py
+++ b/tests/test_dia_validation.py
@@ -1,0 +1,46 @@
+import subprocess
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+import iob
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestDIAValidation(unittest.TestCase):
+    def test_iob_function_requires_positive_dia(self):
+        with self.assertRaises(ValueError):
+            iob.iob_exponential_oref(1.0, 30.0, DIA_hours=0)
+
+        with self.assertRaises(ValueError):
+            iob.iob_exponential_oref(1.0, 30.0, DIA_hours=-3)
+
+    def test_total_requires_positive_dia(self):
+        with self.assertRaises(ValueError):
+            iob.iob_total_from_elapsed([(1.0, 30.0)], DIA_hours=0)
+
+    def test_cli_reports_dia_error(self):
+        result = subprocess.run(
+            [sys.executable, "iob.py", "1", "30", "--dia", "0"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("dia must be a positive number of hours", result.stderr.lower())
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_parse_pairs_requires_positive_dia(self):
+        now = datetime(2024, 1, 1, 12, 0, 0)
+
+        with self.assertRaisesRegex(ValueError, "positive number of hours"):
+            iob.parse_pairs(["1", "30"], now, 0)
+
+        with self.assertRaisesRegex(ValueError, "positive number of hours"):
+            iob.parse_pairs(["1", "30"], now, -5)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_hhmm_validation.py
+++ b/tests/test_hhmm_validation.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+import iob
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestHHMMValidation(unittest.TestCase):
+    def test_parser_rejects_invalid_minute(self):
+        now = datetime(2024, 1, 1, 12, 0, 0)
+        with self.assertRaises(ValueError) as ctx:
+            iob._parse_hhmm_to_elapsed_today_or_yesterday("12:99", now, 5 * 60)
+        self.assertIn("minute must be 0-59", str(ctx.exception))
+
+    def test_cli_reports_invalid_hhmm(self):
+        result = subprocess.run(
+            [sys.executable, "iob.py", "1", "12:99"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("minute must be 0-59", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_peak_validation.py
+++ b/tests/test_peak_validation.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import iob
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestPeakValidation(unittest.TestCase):
+    def test_iob_function_requires_positive_peak(self):
+        with self.assertRaises(ValueError):
+            iob.iob_exponential_oref(1.0, 30.0, PEAK_min=0)
+
+        with self.assertRaises(ValueError):
+            iob.iob_exponential_oref(1.0, 30.0, PEAK_min=-10)
+
+    def test_cli_reports_peak_error(self):
+        result = subprocess.run(
+            [sys.executable, "iob.py", "1", "30", "--peak", "0"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("peak must be a positive", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,0 +1,33 @@
+import unittest
+
+import iob
+
+
+class TestIOBPrecision(unittest.TestCase):
+    def test_total_rounds_once(self):
+        doses = [
+            (1.804925322024908, 83.1664139320608),
+            (2.305398039790803, 210.94229647403006),
+            (2.3763598284324625, 250.0312414589015),
+        ]
+
+        raw_values = [
+            iob.iob_exponential_oref(u, e, round_result=False) for u, e in doses
+        ]
+        expected_total = round(sum(raw_values), 2)
+
+        self.assertEqual(expected_total, iob.iob_total_from_elapsed(doses))
+
+    def test_round_result_flag(self):
+        units = 1.804925322024908
+        elapsed = 83.1664139320608
+
+        raw_value = iob.iob_exponential_oref(units, elapsed, round_result=False)
+        rounded_value = iob.iob_exponential_oref(units, elapsed)
+
+        self.assertNotAlmostEqual(raw_value, rounded_value)
+        self.assertEqual(round(raw_value, 2), rounded_value)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- raise a ValueError in `parse_pairs` when `dia_hours` is non-positive so the parser matches the other DIA validation paths
- extend the DIA validation test suite to cover the parser helper directly

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68ce1b042fa8833180b874e1fb5c12bd